### PR TITLE
Fix the type mismatch bewteen 3d points numpy array and open3d.utility.Vector3dVector

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -138,8 +138,8 @@ def main(args):
     conf_sig_all = (conf_all-1) / conf_all
 
     pcd = o3d.geometry.PointCloud()
-    pcd.points = o3d.utility.Vector3dVector(pts_all[conf_sig_all>args.conf_thresh].reshape(-1, 3))
-    pcd.colors = o3d.utility.Vector3dVector(images_all[conf_sig_all>args.conf_thresh].reshape(-1, 3))
+    pcd.points = o3d.utility.Vector3dVector(pts_all[conf_sig_all>args.conf_thresh].reshape(-1, 3).astype(np.float64))
+    pcd.colors = o3d.utility.Vector3dVector(images_all[conf_sig_all>args.conf_thresh].reshape(-1, 3).astype(np.float64))
     o3d.io.write_point_cloud(os.path.join(save_demo_path, f"{demo_name}_conf{args.conf_thresh}.ply"), pcd)
 
 


### PR DESCRIPTION
https://www.open3d.org/docs/release/python_api/open3d.utility.Vector3dVector.html#open3d.utility.Vector3dVector

The open3d.utility.Vector3dVector requires float64 type, but the code uses float32.

I just converted it.